### PR TITLE
Update mmd.xsd

### DIFF
--- a/xsd/mmd.xsd
+++ b/xsd/mmd.xsd
@@ -208,9 +208,10 @@
         <xs:restriction base="xs:string">
             <xs:enumeration value="HTTP"></xs:enumeration>
             <xs:enumeration value="OPeNDAP"></xs:enumeration>
-            <xs:enumeration value="OGC WMS"></xs:enumeration>
-            <xs:enumeration value="OGC WFS"/>
-            <xs:enumeration value="OGC WCS"/>
+            <xs:enumeration value="OGC:WMS"></xs:enumeration>
+            <xs:enumeration value="OGC:WFS"/>
+            <xs:enumeration value="OGC:WCS"/>
+            <xs:enumeration value="FILE:GEO"/>
             <xs:enumeration value="FTP"/>
         </xs:restriction>
     </xs:simpleType>


### PR DESCRIPTION
Fix string to specify OGC:protocol (WMS, WFS, WCS) used to access `OnlineResource`  int CSW standard - Adding `FILE:GEO` type, used to directly access resources when available on disk.